### PR TITLE
metamath-extract: Abbreviate constants and lemma names to produce smaller proofs. 

### DIFF
--- a/bin/metamath-compress
+++ b/bin/metamath-compress
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Modified from https://github.com/metamath/set.mm/blob/develop/scripts/verify
+
+set -euo pipefail
+
+# We should find a cleaner way of doing this long term.
+mmfile=$1; shift
+log_file=.build/${mmfile}.log
+mkdir -p $(dirname "$log_file")
+metamath > "$log_file" << COMMANDS
+set echo on
+set scroll continuous
+read '${mmfile}'
+save proof * /compressed
+write source
+
+
+quit
+COMMANDS
+
+# Get status, which is false (nonzero) if an error or warning was found.
+! grep -E '[?]Error|[?]Warning' < "$log_file" > /dev/null || {
+    echo "FAILED. See: $log_file";
+    exit 1;
+}
+

--- a/src/proof_generation/scripts/metamath-extract.py
+++ b/src/proof_generation/scripts/metamath-extract.py
@@ -215,7 +215,7 @@ def abbreviate(name: str) -> str:
 
 def abbreviate_constructors(term: Term) -> Term:
     if isinstance(term, Metavariable):
-        return term
+        return Metavariable(abbreviate(term.name))
     elif isinstance(term, Application):
         return Application(abbreviate(term.symbol), term.subterms)
     else:
@@ -233,7 +233,7 @@ def abbreviate_lemmas(statement: Statement) -> Statement:
         new_label = abbreviate(statement.label)
 
         if isinstance(statement, FloatingStatement):
-            return FloatingStatement(new_label, statement.terms)
+            return FloatingStatement(new_label, terms_abbreviate_constructors(statement.terms))
         elif isinstance(statement, EssentialStatement):
             return EssentialStatement(new_label, terms_abbreviate_constructors(statement.terms))
         elif isinstance(statement, AxiomaticStatement):


### PR DESCRIPTION
Also adds sliced and compressed versions of the proofs.
